### PR TITLE
Add .codex-plugin/plugin.json for Codex discoverability

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "cartographer",
+  "version": "1.0.0",
+  "description": "Maps and documents codebases of any size using parallel AI subagents. Creates CODEBASE_MAP.md with architecture, file purposes, dependencies, and navigation guides.",
+  "author": {
+    "name": "Bootoshi",
+    "url": "https://github.com/kingbootoshi"
+  },
+  "repository": "https://github.com/kingbootoshi/cartographer",
+  "license": "MIT",
+  "keywords": ["codebase-mapping", "documentation", "architecture", "subagents"],
+  "skills": "./plugins/cartographer/skills/"
+}


### PR DESCRIPTION
## Summary
- Adds `.codex-plugin/plugin.json` manifest at repo root
- Enables discovery through Codex CLI, OpenCode, and community plugin registries
- Does not modify any existing files

## Context
The `.codex-plugin/plugin.json` manifest format works across Claude Code, Codex CLI, and OpenCode. This makes the plugin findable by Codex users alongside the existing `.claude-plugin` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)