### PR TITLE
fix: add missing version field to plugin.json

### DIFF
--- a/plugins/cartographer/.claude-plugin/plugin.json
+++ b/plugins/cartographer/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "cartographer",
+  "version": "1.4.0",
   "description": "Maps and documents codebases of any size using parallel AI subagents",
   "author": {
     "name": "Bootoshi",


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `plugins/cartographer/.claude-plugin/plugin.json` is missing the `version` field; without it, the Claude Code marketplace falls back to commit SHA as the version, breaking versioned installs like `nlpm@0.x`.

**Evidence**: The manifest has `name`, `description`, and `author` but no `version` key — confirmed by direct inspection. `marketplace.json` already declares `"version": "1.4.0"` for this plugin.

**Fix**: Adds `"version": "1.4.0"` to `plugin.json`, consistent with the value already in `marketplace.json`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:82c8147a2f831b1af549f8fd169dfd4989449bfd78a67750e485a3624ed1adf7"}]}
nlpm-metadata-end -->