### PR TITLE
fix: pin tiktoken version to >=0.7,<1.0

### DIFF
--- a/plugins/cartographer/skills/cartographer/SKILL.md
+++ b/plugins/cartographer/skills/cartographer/SKILL.md
@@ -52,9 +52,9 @@ python3 ${CLAUDE_PLUGIN_ROOT}/skills/cartographer/scripts/scan-codebase.py . --f
 
 If not using UV and tiktoken is missing:
 ```bash
-pip install tiktoken
+pip install 'tiktoken>=0.7,<1.0'
 # or
-pip3 install tiktoken
+pip3 install 'tiktoken>=0.7,<1.0'
 ```
 
 The output provides:
@@ -289,11 +289,11 @@ Always use Sonnet subagents - best balance of capability and cost for file analy
 
 **Scanner fails with tiktoken error:**
 ```bash
-pip install tiktoken
+pip install 'tiktoken>=0.7,<1.0'
 # or
-pip3 install tiktoken
+pip3 install 'tiktoken>=0.7,<1.0'
 # or with uv:
-uv pip install tiktoken
+uv pip install 'tiktoken>=0.7,<1.0'
 ```
 
 **Python not found:**

--- a/plugins/cartographer/skills/cartographer/scripts/scan-codebase.py
+++ b/plugins/cartographer/skills/cartographer/scripts/scan-codebase.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.9"
-# dependencies = ["tiktoken"]
+# dependencies = ["tiktoken>=0.7,<1.0"]
 # ///
 """
 Codebase Scanner for Cartographer


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `tiktoken` is referenced without a version constraint in both the UV inline script spec (`scan-codebase.py` line 4, `# dependencies = ["tiktoken"]`) and the fallback `pip install tiktoken` instructions in `SKILL.md` (lines 55, 57, 292–296). An unpinned runtime install resolves to the latest release on every cold run, allowing a future breaking or compromised release to affect users silently.

**Evidence**: `scan-codebase.py:4` — `# dependencies = ["tiktoken"]` — no specifier. `SKILL.md` — `pip install tiktoken` (×2 locations) — no specifier. Both confirmed by direct file inspection.

**Fix**: Pins all references to `tiktoken>=0.7,<1.0`, consistent with the current stable release series and the API surface used (`cl100k_base` encoding, available since 0.3.x).

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:827054ec3229a694fa06eb856ee427d68b71ed2f4e21a38622004bcea5746a36"},{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:17e9ca994e8dbd1a3f65d9e7b86732e157dcab572853ad85f35267ad1d867323"}]}
nlpm-metadata-end -->